### PR TITLE
ADD: Synchronous functions for BoundedQueue.

### DIFF
--- a/src/Concurrent/BoundedQueue.purs
+++ b/src/Concurrent/BoundedQueue.purs
@@ -3,34 +3,25 @@
 -- | This datastructure is useful in various consumer/producer situations.
 
 module Concurrent.BoundedQueue
-  ( BoundedQueue
-  , new, new'
+  ( new
   , write
   , read
-  , isEmpty, isEmpty'
-  , tryRead, tryRead'
-  , tryWrite, tryWrite'
+  , isEmpty
+  , tryRead
+  , tryWrite
+  , module Export
   ) where
 
 import Prelude
 
+import Concurrent.BoundedQueue.Internal (BoundedQueue(..))
+import Concurrent.BoundedQueue.Internal (BoundedQueue) as Export
 import Data.Array (unsafeIndex)
 import Data.Maybe (Maybe(..))
 import Data.Unfoldable (replicateA)
-import Effect (Effect)
-import Effect.AVar as AVarEff
 import Effect.Aff (Aff)
-import Effect.Aff.AVar (AVar)
 import Effect.Aff.AVar as AVar
 import Partial.Unsafe (unsafePartial)
-
-newtype BoundedQueue a =
-  BoundedQueue
-    { size ∷ Int
-    , contents ∷ Array (AVar a)
-    , readPos ∷ AVar Int
-    , writePos ∷ AVar Int
-    }
 
 -- | Creates a new `BoundedQueue` with the given capacity,
 new ∷ ∀ a. Int → Aff (BoundedQueue a)
@@ -38,14 +29,6 @@ new size = do
   contents ← replicateA size AVar.empty
   readPos ← AVar.new 0
   writePos ← AVar.new 0
-  pure (BoundedQueue { size, contents, readPos, writePos })
-
--- | Synchronously creates a new `BoundedQueue` with the given capacity.
-new' ∷ ∀ a. Int → Effect (BoundedQueue a)
-new' size = do
-  contents ← replicateA size AVarEff.empty
-  readPos ← AVarEff.new 0
-  writePos ← AVarEff.new 0
   pure (BoundedQueue { size, contents, readPos, writePos })
 
 -- | Writes an element to the given queue. Will block if the queue is full until
@@ -74,16 +57,6 @@ isEmpty (BoundedQueue q) = do
       Nothing → true
       Just _ → false
 
--- | Synchronously checks whether the given queue is empty. Never blocks.
-isEmpty' ∷ ∀ a. BoundedQueue a → Effect Boolean
-isEmpty' (BoundedQueue q) = do
-  AVarEff.tryRead q.readPos >>= case _ of
-    Nothing → pure true
-    Just r → AVarEff.tryRead (unsafePartial unsafeIndex q.contents r) <#>
-      case _ of
-        Nothing → true
-        Just _ → false
-
 -- | Attempts to read an element from the given queue. If the queue is empty,
 -- | returns `Nothing`.
 -- |
@@ -100,22 +73,6 @@ tryRead (BoundedQueue q) = do
       AVar.put r q.readPos
       pure Nothing
 
--- | Synchronously attempts to read an element from the given queue. If the
--- | queue is empty, or there is a concurrent reader, returns `Nothing`.
-tryRead' ∷ ∀ a. BoundedQueue a -> Effect (Maybe a)
-tryRead' (BoundedQueue q) = do
-  mr ← AVarEff.tryTake q.readPos
-  case mr of
-    Just r → do
-      AVarEff.tryTake (unsafePartial unsafeIndex q.contents r) >>= case _ of
-        Just v → do
-          _ <- AVarEff.tryPut ((r + 1) `mod` q.size) q.readPos
-          pure (Just v)
-        Nothing → do
-          _ <- AVarEff.tryPut r q.readPos
-          pure Nothing
-    Nothing → pure Nothing
-
 -- | Attempts to write an element into the given queue. If the queue is full,
 -- | returns `false` otherwise `true`.
 -- |
@@ -131,19 +88,3 @@ tryWrite (BoundedQueue q) a = do
     else do
       AVar.put w q.writePos
       pure false
-
--- | Attempts to write an element into the given queue. If the queue is full,
--- | or there is a concurrent writer, returns `false` otherwise `true`.
-tryWrite' ∷ ∀ a. BoundedQueue a → a → Effect Boolean
-tryWrite' (BoundedQueue q) a = do
-  mw ← AVarEff.tryTake q.writePos
-  case mw of
-    Just w → do
-      AVarEff.tryPut a (unsafePartial unsafeIndex q.contents w) >>= if _
-        then do
-          _ ← AVarEff.tryPut ((w + 1) `mod` q.size) q.writePos
-          pure true
-        else do
-          _ ← AVarEff.tryPut w q.writePos
-          pure false
-    Nothing → pure false

--- a/src/Concurrent/BoundedQueue/Internal.purs
+++ b/src/Concurrent/BoundedQueue/Internal.purs
@@ -1,0 +1,13 @@
+module Concurrent.BoundedQueue.Internal
+  ( BoundedQueue(..)
+  ) where
+
+import Effect.AVar (AVar)
+
+newtype BoundedQueue a =
+  BoundedQueue
+    { size     ∷ Int
+    , contents ∷ Array (AVar a)
+    , readPos  ∷ AVar Int
+    , writePos ∷ AVar Int
+    }

--- a/src/Concurrent/BoundedQueue/Sync.purs
+++ b/src/Concurrent/BoundedQueue/Sync.purs
@@ -1,0 +1,69 @@
+module Concurrent.BoundedQueue.Sync
+  ( new
+  , isEmpty
+  , tryRead
+  , tryWrite
+  , module Export
+  )
+where
+
+import Prelude
+
+import Concurrent.BoundedQueue.Internal (BoundedQueue(..))
+import Concurrent.BoundedQueue.Internal (BoundedQueue) as Export
+import Data.Array (unsafeIndex)
+import Data.Maybe (Maybe(..))
+import Data.Unfoldable (replicateA)
+import Effect (Effect)
+import Effect.AVar as AVarEff
+import Partial.Unsafe (unsafePartial)
+
+-- | Synchronously creates a new `BoundedQueue` with the given capacity.
+new ∷ ∀ a. Int → Effect (BoundedQueue a)
+new size = do
+  contents ← replicateA size AVarEff.empty
+  readPos ← AVarEff.new 0
+  writePos ← AVarEff.new 0
+  pure (BoundedQueue { size, contents, readPos, writePos })
+
+-- | Synchronously checks whether the given queue is empty. Never blocks.
+isEmpty ∷ ∀ a. BoundedQueue a → Effect Boolean
+isEmpty (BoundedQueue q) = do
+  AVarEff.tryRead q.readPos >>= case _ of
+    Nothing → pure true
+    Just r → AVarEff.tryRead (unsafePartial unsafeIndex q.contents r) <#>
+      case _ of
+        Nothing → true
+        Just _ → false
+
+-- | Synchronously attempts to read an element from the given queue. If the
+-- | queue is empty, or there is a concurrent reader, returns `Nothing`.
+tryRead ∷ ∀ a. BoundedQueue a -> Effect (Maybe a)
+tryRead (BoundedQueue q) = do
+  mr ← AVarEff.tryTake q.readPos
+  case mr of
+    Just r → do
+      AVarEff.tryTake (unsafePartial unsafeIndex q.contents r) >>= case _ of
+        Just v → do
+          _ <- AVarEff.tryPut ((r + 1) `mod` q.size) q.readPos
+          pure (Just v)
+        Nothing → do
+          _ <- AVarEff.tryPut r q.readPos
+          pure Nothing
+    Nothing → pure Nothing
+
+-- | Attempts to write an element into the given queue. If the queue is full,
+-- | or there is a concurrent writer, returns `false` otherwise `true`.
+tryWrite ∷ ∀ a. BoundedQueue a → a → Effect Boolean
+tryWrite (BoundedQueue q) a = do
+  mw ← AVarEff.tryTake q.writePos
+  case mw of
+    Just w → do
+      AVarEff.tryPut a (unsafePartial unsafeIndex q.contents w) >>= if _
+        then do
+          _ ← AVarEff.tryPut ((w + 1) `mod` q.size) q.writePos
+          pure true
+        else do
+          _ ← AVarEff.tryPut w q.writePos
+          pure false
+    Nothing → pure false

--- a/test/BoundedQueue.purs
+++ b/test/BoundedQueue.purs
@@ -3,11 +3,14 @@ module Test.BoundedQueue where
 import Prelude
 
 import Concurrent.BoundedQueue as BQ
+import Concurrent.BoundedQueue.Sync as BQS
 import Control.Alt ((<|>))
 import Data.Either (Either(..), isLeft, isRight)
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..), isNothing)
+import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff, Milliseconds(..), delay, forkAff, parallel, sequential)
+import Effect.Class (liftEffect)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert as Assert
 
@@ -85,3 +88,80 @@ boundedQueueSuite = do
       _ ← forkAff (BQ.write q 2)
       r ← race (delayMs 20) (BQ.tryWrite q 2)
       Assert.assert "Should've been Left" (isLeft r)
+
+boundedQueueSyncSuite :: TestSuite
+boundedQueueSyncSuite = do
+  suite "(Sync) Simple operations" do
+    test "(Sync) inserting and popping elements" do
+      q ← liftEffect (BQS.new 2)
+      BQ.write q 1
+      BQ.write q 2
+      r1 ← BQ.read q
+      r2 ← BQ.read q
+      Assert.equal r1 1
+      Assert.equal r2 2
+  suite "(Sync) Blocking and unblocking" do
+    test "(Sync) writing more than the allowed capacity blocks" do
+      q ← liftEffect (BQS.new 1)
+      BQ.write q 1
+      r ← race (delayMs 50) (BQ.write q 2)
+      Assert.assert "Not blocked" (isLeft r)
+    test "(Sync) reading unblocks writes blocked on missing capacity" do
+      q ← liftEffect (BQS.new 1)
+      BQ.write q 1
+      _ ← forkAff (delayMs 20 *> (BQ.read q))
+      r ← race (delayMs 50) (BQ.write q 2)
+      Assert.assert "Blocked too long" (isRight r)
+  suite "(Sync) isEmpty" do
+    test "(Sync) an empty queue is empty" do
+      r ← liftEffect do
+        q ← BQS.new 1
+        BQS.isEmpty q
+      Assert.assert "" r
+    test "(Sync) an empty queue with blocked readers is empty" do
+      q ← BQ.new 1
+      _ ← forkAff (BQ.read q)
+      r ← BQ.isEmpty q
+      Assert.assert "" r
+  suite "(Sync) tryRead blocking and unblocking" do
+    test "(Sync) tryRead is non-blocking for empty queue" do
+      r ← liftEffect do
+        q ← BQS.new 1
+        BQS.tryRead q
+      Assert.assert "Should've been Nothing" (isNothing r)
+    test "(Sync) tryRead reads from a non-empty queue" do
+      q ← liftEffect (BQS.new 1)
+      BQ.write q 1
+      Tuple r1 r2 ← liftEffect do
+        r1 ← BQS.tryRead q
+        r2 ← BQS.tryRead q
+        pure (Tuple r1 r2)
+      Assert.equal r1 (Just 1)
+      Assert.assert "Should've been Nothing" (isNothing r2)
+    test ("(Sync) tryRead does not block when there are consumers blocked on "
+      <> "the queue") do
+      q ← liftEffect (BQS.new 1)
+      _ ← forkAff (BQ.read q)
+      r ← race (delayMs 20) (liftEffect (BQS.tryRead q))
+      Assert.assert "Should've been Right" (isRight r)
+  suite "(Sync) tryWrite blocking and unblocking" do
+    test "(Sync) tryWrite is non-blocking for full queue" do
+      q ← liftEffect (BQS.new 1)
+      BQ.write q 1
+      r ← liftEffect (BQS.tryWrite q 2)
+      Assert.assertFalse "Write should've failed" r
+    test "(Sync) tryWrite writes to a non-full queue" do
+      Tuple q rw ← do
+        q ← BQ.new 1
+        rw ← BQ.tryWrite q 1
+        pure (Tuple q rw)
+      r ← BQ.read q
+      Assert.assert "tryWrite should've succeeded" rw
+      Assert.equal r 1
+    test ("(Sync) tryWrite does not block when there are writers blocked on " <>
+      "the queue") do
+      q ← liftEffect (BQS.new 1)
+      BQ.write q 1
+      _ ← forkAff (BQ.write q 2)
+      r ← race (delayMs 20) (liftEffect (BQS.tryWrite q 2))
+      Assert.assert "Should've been Right" (isRight r)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,7 +3,7 @@ module Test.Main where
 import Prelude
 
 import Effect (Effect)
-import Test.BoundedQueue (boundedQueueSuite)
+import Test.BoundedQueue (boundedQueueSuite, boundedQueueSyncSuite)
 import Test.Queue (queueSuite)
 import Test.Unit (suite)
 import Test.Unit.Main (runTest)
@@ -12,3 +12,4 @@ main ∷ Effect Unit
 main = runTest do
   suite "Queue" queueSuite
   suite "BoundedQueue" boundedQueueSuite
+  suite "(Sync) BoundedQueue" boundedQueueSyncSuite


### PR DESCRIPTION
You'll probably want me to add tests and equivalent functions for unbounded queues, but just looking for comments for now.

Motivation is that you sometimes have to interface with Effect callbacks. The issue with launching multiple Aff fibers is that you then cannot know in what order they will run. In turn, that means you cannot know what order items will be queued.