### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#13 by @thomashoneyman)
 
 ## [v2.0.0](https://github.com/purescript-contrib/purescript-concurrent-queues/releases/tag/v2.0.0) - 2021-02-26
 

--- a/src/Concurrent/BoundedQueue.purs
+++ b/src/Concurrent/BoundedQueue.purs
@@ -24,52 +24,52 @@ import Effect.Aff.AVar as AVar
 import Partial.Unsafe (unsafePartial)
 
 -- | Creates a new `BoundedQueue` with the given capacity,
-new ∷ ∀ a. Int → Aff (BoundedQueue a)
+new :: forall a. Int -> Aff (BoundedQueue a)
 new size = do
-  contents ← replicateA size AVar.empty
-  readPos ← AVar.new 0
-  writePos ← AVar.new 0
+  contents <- replicateA size AVar.empty
+  readPos <- AVar.new 0
+  writePos <- AVar.new 0
   pure (BoundedQueue { size, contents, readPos, writePos })
 
 -- | Writes an element to the given queue. Will block if the queue is full until
 -- | someone reads from it.
-write ∷ ∀ a. BoundedQueue a → a → Aff Unit
+write :: forall a. BoundedQueue a -> a -> Aff Unit
 write (BoundedQueue q) a = do
-  w ← AVar.take q.writePos
+  w <- AVar.take q.writePos
   AVar.put a (unsafePartial unsafeIndex q.contents w)
   AVar.put ((w + 1) `mod` q.size) q.writePos
 
 -- | Reads an element from the given queue, will block if the queue is empty,
 -- | until someone writes to it.
-read ∷ ∀ a. BoundedQueue a → Aff a
+read :: forall a. BoundedQueue a -> Aff a
 read (BoundedQueue q) = do
-  r ← AVar.take q.readPos
-  v ← AVar.take (unsafePartial unsafeIndex q.contents r)
+  r <- AVar.take q.readPos
+  v <- AVar.take (unsafePartial unsafeIndex q.contents r)
   AVar.put ((r + 1) `mod` q.size) q.readPos
   pure v
 
 -- | Checks whether the given queue is empty. Never blocks.
-isEmpty ∷ ∀ a. BoundedQueue a → Aff Boolean
+isEmpty :: forall a. BoundedQueue a -> Aff Boolean
 isEmpty (BoundedQueue q) = do
   AVar.tryRead q.readPos >>= case _ of
-    Nothing → pure true
-    Just r → AVar.tryRead (unsafePartial unsafeIndex q.contents r) <#> case _ of
-      Nothing → true
-      Just _ → false
+    Nothing -> pure true
+    Just r -> AVar.tryRead (unsafePartial unsafeIndex q.contents r) <#> case _ of
+      Nothing -> true
+      Just _ -> false
 
 -- | Attempts to read an element from the given queue. If the queue is empty,
 -- | returns `Nothing`.
 -- |
 -- | *Careful!* If other readers are blocked on the queue `tryRead` will also
 -- | block.
-tryRead ∷ ∀ a. BoundedQueue a → Aff (Maybe a)
+tryRead :: forall a. BoundedQueue a -> Aff (Maybe a)
 tryRead (BoundedQueue q) = do
-  r ← AVar.take q.readPos
+  r <- AVar.take q.readPos
   AVar.tryTake (unsafePartial unsafeIndex q.contents r) >>= case _ of
-    Just v → do
+    Just v -> do
       AVar.put ((r + 1) `mod` q.size) q.readPos
       pure (Just v)
-    Nothing → do
+    Nothing -> do
       AVar.put r q.readPos
       pure Nothing
 
@@ -78,11 +78,11 @@ tryRead (BoundedQueue q) = do
 -- |
 -- | *Careful!* If other writers are blocked on the queue `tryWrite` will also
 -- | block.
-tryWrite ∷ ∀ a. BoundedQueue a → a → Aff Boolean
+tryWrite :: forall a. BoundedQueue a -> a -> Aff Boolean
 tryWrite (BoundedQueue q) a = do
-  w ← AVar.take q.writePos
-  AVar.tryPut a (unsafePartial unsafeIndex q.contents w) >>= if _
-    then do
+  w <- AVar.take q.writePos
+  AVar.tryPut a (unsafePartial unsafeIndex q.contents w) >>=
+    if _ then do
       AVar.put ((w + 1) `mod` q.size) q.writePos
       pure true
     else do

--- a/src/Concurrent/BoundedQueue/Internal.purs
+++ b/src/Concurrent/BoundedQueue/Internal.purs
@@ -6,8 +6,8 @@ import Effect.AVar (AVar)
 
 newtype BoundedQueue a =
   BoundedQueue
-    { size     ∷ Int
-    , contents ∷ Array (AVar a)
-    , readPos  ∷ AVar Int
-    , writePos ∷ AVar Int
+    { size :: Int
+    , contents :: Array (AVar a)
+    , readPos :: AVar Int
+    , writePos :: AVar Int
     }

--- a/src/Concurrent/BoundedQueue/Sync.purs
+++ b/src/Concurrent/BoundedQueue/Sync.purs
@@ -4,8 +4,7 @@ module Concurrent.BoundedQueue.Sync
   , tryRead
   , tryWrite
   , module Export
-  )
-where
+  ) where
 
 import Prelude
 
@@ -19,51 +18,51 @@ import Effect.AVar as AVarEff
 import Partial.Unsafe (unsafePartial)
 
 -- | Synchronously creates a new `BoundedQueue` with the given capacity.
-new ∷ ∀ a. Int → Effect (BoundedQueue a)
+new :: forall a. Int -> Effect (BoundedQueue a)
 new size = do
-  contents ← replicateA size AVarEff.empty
-  readPos ← AVarEff.new 0
-  writePos ← AVarEff.new 0
+  contents <- replicateA size AVarEff.empty
+  readPos <- AVarEff.new 0
+  writePos <- AVarEff.new 0
   pure (BoundedQueue { size, contents, readPos, writePos })
 
 -- | Synchronously checks whether the given queue is empty. Never blocks.
-isEmpty ∷ ∀ a. BoundedQueue a → Effect Boolean
+isEmpty :: forall a. BoundedQueue a -> Effect Boolean
 isEmpty (BoundedQueue q) = do
   AVarEff.tryRead q.readPos >>= case _ of
-    Nothing → pure true
-    Just r → AVarEff.tryRead (unsafePartial unsafeIndex q.contents r) <#>
+    Nothing -> pure true
+    Just r -> AVarEff.tryRead (unsafePartial unsafeIndex q.contents r) <#>
       case _ of
-        Nothing → true
-        Just _ → false
+        Nothing -> true
+        Just _ -> false
 
 -- | Synchronously attempts to read an element from the given queue. If the
 -- | queue is empty, or there is a concurrent reader, returns `Nothing`.
-tryRead ∷ ∀ a. BoundedQueue a -> Effect (Maybe a)
+tryRead :: forall a. BoundedQueue a -> Effect (Maybe a)
 tryRead (BoundedQueue q) = do
-  mr ← AVarEff.tryTake q.readPos
+  mr <- AVarEff.tryTake q.readPos
   case mr of
-    Just r → do
+    Just r -> do
       AVarEff.tryTake (unsafePartial unsafeIndex q.contents r) >>= case _ of
-        Just v → do
+        Just v -> do
           _ <- AVarEff.tryPut ((r + 1) `mod` q.size) q.readPos
           pure (Just v)
-        Nothing → do
+        Nothing -> do
           _ <- AVarEff.tryPut r q.readPos
           pure Nothing
-    Nothing → pure Nothing
+    Nothing -> pure Nothing
 
 -- | Attempts to write an element into the given queue. If the queue is full,
 -- | or there is a concurrent writer, returns `false` otherwise `true`.
-tryWrite ∷ ∀ a. BoundedQueue a → a → Effect Boolean
+tryWrite :: forall a. BoundedQueue a -> a -> Effect Boolean
 tryWrite (BoundedQueue q) a = do
-  mw ← AVarEff.tryTake q.writePos
+  mw <- AVarEff.tryTake q.writePos
   case mw of
-    Just w → do
-      AVarEff.tryPut a (unsafePartial unsafeIndex q.contents w) >>= if _
-        then do
-          _ ← AVarEff.tryPut ((w + 1) `mod` q.size) q.writePos
+    Just w -> do
+      AVarEff.tryPut a (unsafePartial unsafeIndex q.contents w) >>=
+        if _ then do
+          _ <- AVarEff.tryPut ((w + 1) `mod` q.size) q.writePos
           pure true
         else do
-          _ ← AVarEff.tryPut w q.writePos
+          _ <- AVarEff.tryPut w q.writePos
           pure false
-    Nothing → pure false
+    Nothing -> pure false

--- a/test/BoundedQueue.purs
+++ b/test/BoundedQueue.purs
@@ -141,10 +141,7 @@ boundedQueueSyncSuite = do
         pure (Tuple r1 r2)
       r1 `shouldEqual` (Just 1)
       assert "Should've been Nothing" (isNothing r2)
-    test
-      ( "(Sync) tryRead does not block when there are consumers blocked on "
-          <> "the queue"
-      ) $ liftAff do
+    test "(Sync) tryRead does not block when there are consumers blocked on the queue" $ liftAff do
       q <- liftEffect (BQS.new 1)
       _ <- forkAff (BQ.read q)
       r <- race (delayMs 20) (liftEffect (BQS.tryRead q))
@@ -163,10 +160,7 @@ boundedQueueSyncSuite = do
       r <- BQ.read q
       assert "tryWrite should've succeeded" rw
       r `shouldEqual` 1
-    test
-      ( "(Sync) tryWrite does not block when there are writers blocked on " <>
-          "the queue"
-      ) $ liftAff do
+    test "(Sync) tryWrite does not block when there are writers blocked on the queue" $ liftAff do
       q <- liftEffect (BQS.new 1)
       BQ.write q 1
       _ <- forkAff (BQ.write q 2)

--- a/test/BoundedQueue.purs
+++ b/test/BoundedQueue.purs
@@ -15,156 +15,160 @@ import Effect.Class (liftEffect)
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Test.Util (suite, test, shouldEqual, assert, assertFalse)
 
-race ∷ ∀ a b. Aff a → Aff b → Aff (Either a b)
+race :: forall a b. Aff a -> Aff b -> Aff (Either a b)
 race a b = sequential ((parallel (map Left a)) <|> (parallel (map Right b)))
 
-delayMs ∷ Int → Aff Unit
+delayMs :: Int -> Aff Unit
 delayMs = delay <<< Milliseconds <<< toNumber
 
-boundedQueueSuite ∷ forall m. MonadReader Int m ⇒ MonadAff m ⇒ m Unit
+boundedQueueSuite :: forall m. MonadReader Int m => MonadAff m => m Unit
 boundedQueueSuite = do
   suite "Simple operations" do
     test "inserting and popping elements" $ liftAff do
-      q ← BQ.new 2
+      q <- BQ.new 2
       BQ.write q 1
       BQ.write q 2
-      r1 ← BQ.read q
-      r2 ← BQ.read q
+      r1 <- BQ.read q
+      r2 <- BQ.read q
       r1 `shouldEqual` 1
       r2 `shouldEqual` 2
   suite "Blocking and unblocking" do
     test "writing more than the allowed capacity blocks" $ liftAff do
-      q ← BQ.new 1
+      q <- BQ.new 1
       BQ.write q 1
-      r ← race (delayMs 50) (BQ.write q 2)
+      r <- race (delayMs 50) (BQ.write q 2)
       assert "Not blocked" (isLeft r)
     test "reading unblocks writes blocked on missing capacity" $ liftAff do
-      q ← BQ.new 1
+      q <- BQ.new 1
       BQ.write q 1
-      _ ← forkAff (delayMs 20 *> (BQ.read q))
-      r ← race (delayMs 50) (BQ.write q 2)
+      _ <- forkAff (delayMs 20 *> (BQ.read q))
+      r <- race (delayMs 50) (BQ.write q 2)
       assert "Blocked too long" (isRight r)
   suite "isEmpty" do
     test "an empty queue is empty" $ liftAff do
-      q ← BQ.new 1
-      r ← BQ.isEmpty q
+      q <- BQ.new 1
+      r <- BQ.isEmpty q
       assert "" r
     test "an empty queue with blocked readers is empty" $ liftAff do
-      q ← BQ.new 1
-      _ ← forkAff (BQ.read q)
-      r ← BQ.isEmpty q
+      q <- BQ.new 1
+      _ <- forkAff (BQ.read q)
+      r <- BQ.isEmpty q
       assert "" r
   suite "tryRead blocking and unblocking" do
     test "tryRead is non-blocking for empty queue" $ liftAff do
-      q ← BQ.new 1
-      r ← BQ.tryRead q
+      q <- BQ.new 1
+      r <- BQ.tryRead q
       assert "Should've been Nothing" (isNothing r)
     test "tryRead reads from a non-empty queue" $ liftAff do
-      q ← BQ.new 1
+      q <- BQ.new 1
       BQ.write q 1
-      r1 ← BQ.tryRead q
-      r2 ← BQ.tryRead q
+      r1 <- BQ.tryRead q
+      r2 <- BQ.tryRead q
       r1 `shouldEqual` (Just 1)
       assert "Should've been Nothing" (isNothing r2)
     test "tryRead blocks when there are consumers blocked on the queue" $ liftAff do
-      q ← BQ.new 1
-      _ ← forkAff (BQ.read q)
-      r ← race (delayMs 20) (BQ.tryRead q)
+      q <- BQ.new 1
+      _ <- forkAff (BQ.read q)
+      r <- race (delayMs 20) (BQ.tryRead q)
       assert "Should've been Left" (isLeft r)
   suite "tryWrite blocking and unblocking" do
     test "tryWrite is non-blocking for full queue" $ liftAff do
-      q ← BQ.new 1
+      q <- BQ.new 1
       BQ.write q 1
-      r ← BQ.tryWrite q 2
+      r <- BQ.tryWrite q 2
       assertFalse "Write should've failed" r
     test "tryWrite writes to a non-full queue" $ liftAff do
-      q ← BQ.new 1
-      rw ← BQ.tryWrite q 1
-      r ← BQ.read q
+      q <- BQ.new 1
+      rw <- BQ.tryWrite q 1
+      r <- BQ.read q
       assert "tryWrite should've succeeded" rw
       r `shouldEqual` 1
     test "tryWrite blocks when there are writers blocked on the queue" $ liftAff do
-      q ← BQ.new 1
+      q <- BQ.new 1
       BQ.write q 1
-      _ ← forkAff (BQ.write q 2)
-      r ← race (delayMs 20) (BQ.tryWrite q 2)
+      _ <- forkAff (BQ.write q 2)
+      r <- race (delayMs 20) (BQ.tryWrite q 2)
       assert "Should've been Left" (isLeft r)
 
-boundedQueueSyncSuite :: forall m. MonadReader Int m ⇒ MonadAff m ⇒ m Unit
+boundedQueueSyncSuite :: forall m. MonadReader Int m => MonadAff m => m Unit
 boundedQueueSyncSuite = do
   suite "(Sync) Simple operations" do
     test "(Sync) inserting and popping elements" $ liftAff do
-      Tuple r1 r2 ← liftEffect do
-        q ← liftEffect (BQS.new 2)
-        _ ← BQS.tryWrite q 1
-        _ ← BQS.tryWrite q 2
-        r1 ← BQS.tryRead q
-        r2 ← BQS.tryRead q
+      Tuple r1 r2 <- liftEffect do
+        q <- liftEffect (BQS.new 2)
+        _ <- BQS.tryWrite q 1
+        _ <- BQS.tryWrite q 2
+        r1 <- BQS.tryRead q
+        r2 <- BQS.tryRead q
         pure (Tuple r1 r2)
       r1 `shouldEqual` (Just 1)
       r2 `shouldEqual` (Just 2)
   suite "(Sync) Blocking and unblocking" do
     test "(Sync) writing more than the allowed capacity blocks" $ liftAff do
-      q ← liftEffect (BQS.new 1)
+      q <- liftEffect (BQS.new 1)
       BQ.write q 1
-      r ← race (delayMs 50) (BQ.write q 2)
+      r <- race (delayMs 50) (BQ.write q 2)
       assert "Not blocked" (isLeft r)
     test "(Sync) reading unblocks writes blocked on missing capacity" $ liftAff do
-      q ← liftEffect (BQS.new 1)
+      q <- liftEffect (BQS.new 1)
       BQ.write q 1
-      _ ← forkAff (delayMs 20 *> (BQ.read q))
-      r ← race (delayMs 50) (BQ.write q 2)
+      _ <- forkAff (delayMs 20 *> (BQ.read q))
+      r <- race (delayMs 50) (BQ.write q 2)
       assert "Blocked too long" (isRight r)
   suite "(Sync) isEmpty" do
     test "(Sync) an empty queue is empty" $ liftAff do
-      r ← liftEffect do
-        q ← BQS.new 1
+      r <- liftEffect do
+        q <- BQS.new 1
         BQS.isEmpty q
       assert "" r
     test "(Sync) an empty queue with blocked readers is empty" $ liftAff do
-      q ← liftEffect (BQS.new 1)
-      _ ← forkAff (BQ.read q)
-      r ← liftEffect (BQS.isEmpty q)
+      q <- liftEffect (BQS.new 1)
+      _ <- forkAff (BQ.read q)
+      r <- liftEffect (BQS.isEmpty q)
       assert "" r
   suite "(Sync) tryRead blocking and unblocking" do
     test "(Sync) tryRead is non-blocking for empty queue" $ liftAff do
-      r ← liftEffect do
-        q ← BQS.new 1
+      r <- liftEffect do
+        q <- BQS.new 1
         BQS.tryRead q
       assert "Should've been Nothing" (isNothing r)
     test "(Sync) tryRead reads from a non-empty queue" $ liftAff do
-      q ← liftEffect (BQS.new 1)
+      q <- liftEffect (BQS.new 1)
       BQ.write q 1
-      Tuple r1 r2 ← liftEffect do
-        r1 ← BQS.tryRead q
-        r2 ← BQS.tryRead q
+      Tuple r1 r2 <- liftEffect do
+        r1 <- BQS.tryRead q
+        r2 <- BQS.tryRead q
         pure (Tuple r1 r2)
       r1 `shouldEqual` (Just 1)
       assert "Should've been Nothing" (isNothing r2)
-    test ("(Sync) tryRead does not block when there are consumers blocked on "
-      <> "the queue") $ liftAff do
-      q ← liftEffect (BQS.new 1)
-      _ ← forkAff (BQ.read q)
-      r ← race (delayMs 20) (liftEffect (BQS.tryRead q))
+    test
+      ( "(Sync) tryRead does not block when there are consumers blocked on "
+          <> "the queue"
+      ) $ liftAff do
+      q <- liftEffect (BQS.new 1)
+      _ <- forkAff (BQ.read q)
+      r <- race (delayMs 20) (liftEffect (BQS.tryRead q))
       assert "Should've been Right" (isRight r)
   suite "(Sync) tryWrite blocking and unblocking" do
     test "(Sync) tryWrite is non-blocking for full queue" $ liftAff do
-      q ← liftEffect (BQS.new 1)
+      q <- liftEffect (BQS.new 1)
       BQ.write q 1
-      r ← liftEffect (BQS.tryWrite q 2)
+      r <- liftEffect (BQS.tryWrite q 2)
       assertFalse "Write should've failed" r
     test "(Sync) tryWrite writes to a non-full queue" $ liftAff do
-      Tuple q rw ← liftEffect do
-        q ← BQS.new 1
-        rw ← BQS.tryWrite q 1
+      Tuple q rw <- liftEffect do
+        q <- BQS.new 1
+        rw <- BQS.tryWrite q 1
         pure (Tuple q rw)
-      r ← BQ.read q
+      r <- BQ.read q
       assert "tryWrite should've succeeded" rw
       r `shouldEqual` 1
-    test ("(Sync) tryWrite does not block when there are writers blocked on " <>
-      "the queue") $ liftAff do
-      q ← liftEffect (BQS.new 1)
+    test
+      ( "(Sync) tryWrite does not block when there are writers blocked on " <>
+          "the queue"
+      ) $ liftAff do
+      q <- liftEffect (BQS.new 1)
       BQ.write q 1
-      _ ← forkAff (BQ.write q 2)
-      r ← race (delayMs 20) (liftEffect (BQS.tryWrite q 2))
+      _ <- forkAff (BQ.write q 2)
+      r <- race (delayMs 20) (liftEffect (BQS.tryWrite q 2))
       assert "Should've been Right" (isRight r)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,7 +9,7 @@ import Test.BoundedQueue (boundedQueueSuite, boundedQueueSyncSuite)
 import Test.Queue (queueSuite)
 import Test.Util (suite)
 
-main ∷ Effect Unit
+main :: Effect Unit
 main = launchAff_ $ flip runReaderT 0 do
   suite "Queue" queueSuite
   suite "BoundedQueue" boundedQueueSuite

--- a/test/Queue.purs
+++ b/test/Queue.purs
@@ -12,50 +12,50 @@ import Effect.Aff (Aff, Milliseconds(..), delay, forkAff, parallel, sequential)
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Test.Util (suite, test, shouldEqual, assert)
 
-race ∷ ∀ a b. Aff a → Aff b → Aff (Either a b)
+race :: forall a b. Aff a -> Aff b -> Aff (Either a b)
 race a b = sequential ((parallel (map Left a)) <|> (parallel (map Right b)))
 
-delayMs ∷ Int → Aff Unit
+delayMs :: Int -> Aff Unit
 delayMs = delay <<< Milliseconds <<< toNumber
 
-queueSuite ∷ forall m. MonadReader Int m ⇒ MonadAff m ⇒ m Unit
+queueSuite :: forall m. MonadReader Int m => MonadAff m => m Unit
 queueSuite = do
   suite "Simple operations" do
     test "inserting and popping elements" $ liftAff do
-      q ← Q.new
+      q <- Q.new
       Q.write q 1
       Q.write q 2
-      r1 ← Q.read q
-      r2 ← Q.read q
+      r1 <- Q.read q
+      r2 <- Q.read q
       Q.write q 3
-      r3 ← Q.read q
+      r3 <- Q.read q
       r1 `shouldEqual` 1
       r2 `shouldEqual` 2
       r3 `shouldEqual` 3
   suite "Blocking and unblocking" do
     test "reading from an empty Queue blocks" $ liftAff do
-      q ← Q.new
-      r ← race (delayMs 50) (Q.read q)
+      q <- Q.new
+      r <- race (delayMs 50) (Q.read q)
       assert "Not blocked" (isLeft r)
     test "writing unblocks reads" $ liftAff do
-      q ← Q.new
-      _ ← forkAff (delayMs 20 *> (Q.write q 1))
-      r ← race (delayMs 50) (Q.read q)
+      q <- Q.new
+      _ <- forkAff (delayMs 20 *> (Q.write q 1))
+      r <- race (delayMs 50) (Q.read q)
       assert "Blocked too long" (isRight r)
   suite "tryRead blocking and unblocking" do
     test "tryRead is non-blocking for empty queue" $ liftAff do
-      q ← Q.new
-      r ← Q.tryRead q
+      q <- Q.new
+      r <- Q.tryRead q
       assert "Should've been Nothing" (isNothing r)
     test "tryRead reads from a non-empty queue" $ liftAff do
-      q ← Q.new
+      q <- Q.new
       Q.write q 1
-      r1 ← Q.tryRead q
-      r2 ← Q.tryRead q
+      r1 <- Q.tryRead q
+      r2 <- Q.tryRead q
       r1 `shouldEqual` (Just 1)
       assert "Should've been Nothing" (isNothing r2)
     test "tryRead blocks when there are consumers blocked on the queue" $ liftAff do
-      q ← Q.new
-      _ ← forkAff (Q.read q)
-      r ← race (delayMs 20) (Q.tryRead q)
+      q <- Q.new
+      _ <- forkAff (Q.read q)
+      r <- race (delayMs 20) (Q.tryRead q)
       assert "Should've been Left" (isLeft r)

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -14,17 +14,17 @@ import Test.Assert (assertEqual)
 
 -- Provide similar API to purescript-test-unit to reduce code changes
 
-suite :: forall m. MonadReader Int m ⇒ MonadAff m ⇒ String -> m Unit -> m Unit
+suite :: forall m. MonadReader Int m => MonadAff m => String -> m Unit -> m Unit
 suite = test
 
-test :: forall m. MonadReader Int m ⇒ MonadAff m ⇒ String -> m Unit -> m Unit
+test :: forall m. MonadReader Int m => MonadAff m => String -> m Unit -> m Unit
 test msg runTest = do
   indentation <- ask
   let spacing = guard (indentation > 0) " "
   liftEffect $ log $ (power ">>" indentation) <> spacing <> msg
   local (_ + 1) runTest
 
-shouldEqual :: forall m a. MonadAff m ⇒ Eq a ⇒ Show a ⇒ a -> a -> m Unit
+shouldEqual :: forall m a. MonadAff m => Eq a => Show a => a -> a -> m Unit
 shouldEqual actual expected =
   liftEffect $ assertEqual { actual, expected }
 


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
